### PR TITLE
get switch input status every tick

### DIFF
--- a/mpf/platforms/opp/opp.py
+++ b/mpf/platforms/opp/opp.py
@@ -482,8 +482,7 @@ class HardwarePlatform(MatrixLightsPlatform, LedPlatform, SwitchPlatform, Driver
         while not self.receive_queue.empty():
             self.process_received_message(self.receive_queue.get(False))
 
-        if curr_tick == 0:
-            self.opp_connection.send(self.read_input_msg)
+        self.opp_connection.send(self.read_input_msg)
 
     @classmethod
     def _verify_coil_and_switch_fit(cls, switch, coil):


### PR DESCRIPTION
Changed the poll rate of the switch-inputs from every tenth tick to every tick.
Still not really happy with this since it should be faster than every 33ms.
